### PR TITLE
add TabColor support to ParseXLSX

### DIFF
--- a/lib/Spreadsheet/ParseXLSX.pm
+++ b/lib/Spreadsheet/ParseXLSX.pm
@@ -128,6 +128,11 @@ sub _parse_sheet {
     my $self = shift;
     my ($sheet, $sheet_xml) = @_;
 
+    my ($tab_color) = $sheet_xml->find_nodes('//sheetPr/tabColor');
+    if ($tab_color) {
+        $sheet->{TabColor} = $self->_color($sheet->{_Book}{Color}, $tab_color);
+    }
+
     my @cells = $sheet_xml->find_nodes('//sheetData/row/c');
 
     if (@cells) {


### PR DESCRIPTION
Hello,

ParseExcel supports getting the worksheet tab color since v0.61.  This patch sets the TabColor property of the worksheet object for ParseXLSX.  Thank you and have a great day!

Cheers,
Fitz
