### PR TITLE
support sheet state veryHidden

### DIFF
--- a/lib/Spreadsheet/ParseXLSX.pm
+++ b/lib/Spreadsheet/ParseXLSX.pm
@@ -184,7 +184,11 @@ sub _parse_workbook {
               _Book    => $workbook,
               _SheetNo => $idx,
           );
-          $sheet->{SheetHidden} = 1 if defined $_->att('state') and $_->att('state') eq 'hidden';
+          my $state = $_->att('state');
+          if (defined $state) {
+              $sheet->{SheetHidden} = 1 if $state eq 'hidden';
+              $sheet->{SheetHidden} = 2 if $state eq 'veryHidden';
+          }
           $self->_parse_sheet($sheet, $files->{sheets}{$idx});
           ($sheet)
         } else {


### PR DESCRIPTION
A sheet can be set to veryHidden via VBA macro and can only be unhidden via VBA. See https://docs.microsoft.com/en-us/office/troubleshoot/excel/hide-sheet-and-use-xlveryhidden#hiding-a-sheet-with-a-visual-basic-macro

The Python xlsx modules support veryHidden. See,
https://github.com/chronossc/openpyxl/blob/5f6a7b80d2f58b089ec6ca19cac22c9e95bb04c0/openpyxl/worksheet.py#L199
https://xlrd.readthedocs.io/en/latest/api.html#xlrd.sheet.Sheet.visibility

This Spreadsheet::ParseXLSX is the best xlsx parser module in the Perl space. We need it to also support veryHidden!